### PR TITLE
fix require eslint-friendly-formatter without decision

### DIFF
--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -2,7 +2,9 @@ var path = require('path')
 var utils = require('./utils')
 var config = require('../config')
 var vueLoaderConfig = require('./vue-loader.conf')
+{{#lint}}
 var eslintFriendlyFormatter = require('eslint-friendly-formatter')
+{{/lint}}
 
 function resolve (dir) {
   return path.join(__dirname, '..', dir)


### PR DESCRIPTION
Don't use eslint will be dished out the "Cannot find module" error.